### PR TITLE
Specify output directory for binary executables

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,12 @@ Default: `src`
 
 This directory is where crates must be find.
 
+### RUSTBINDIR ###
+
+Default: `.`
+
+This directory is where runnable crates' binaries will be stored.
+
 ### RUSTLIBDIR ###
 
 Default: `lib`

--- a/rust.mk
+++ b/rust.mk
@@ -34,6 +34,7 @@ RUSTDEBUG               ?=  0
 RUSTAUTORULES           ?=  1
 RUSTBUILDDIR            ?=  .rust
 RUSTSRCDIR              ?=  src
+RUSTBINDIR              ?=  .
 RUSTLIBDIR              ?=  lib
 RUSTINSTALLDIR          ?=  ~/.rust
 
@@ -59,6 +60,8 @@ rwildcard=$(foreach d,$(wildcard $1*),$(call rwildcard,$d/,$2) \
 define RUST_CRATE_BIN
 
 $(1)_ROOT               =   $$($(1)_DIRNAME)/main.rs
+$(1)_PREFIX             =   $$(RUSTBINDIR)/
+$(1)_RUSTCFLAGS_BUILD   +=  --out-dir $$(RUSTBINDIR)
 $(1)_INSTALLDIR         =   $$(RUSTINSTALLDIR)/bin
 
 endef
@@ -180,6 +183,7 @@ install:
 uninstall:
 
 $(eval $(call CREATE_DIR,$(RUSTBUILDDIR)))
+$(eval $(call CREATE_DIR,$(RUSTBINDIR)))
 $(eval $(call CREATE_DIR,$(RUSTLIBDIR)))
 
 ifeq ($(RUSTAUTORULES),1)
@@ -189,5 +193,5 @@ endif
 fclean:                 clean
 
 fclean_dirs:
-	rm -rf $(RUSTLIBDIR) $(RUSTBUILDDIR) doc
+	rm -rf $(RUSTLIBDIR) $(RUSTBINDIR) $(RUSTBUILDDIR) doc
 .PHONY fclean:          fclean_dirs


### PR DESCRIPTION
I was getting annoyed having to add a new entry to my project's `.gitignore` whenever I produced a new executable. This change adds a `RUSTBINDIR` variable (set to `bin` by default) which allows the user to place the executable outputs of crates in their own directory. Installed executables are still always placed in `$$(RUSTINSTALLDIR)/bin`.

If you'd like default behavior to remain the same I can change the default to `.`, but I think this is nicer.
